### PR TITLE
add docker-compose config for easier docker management and fix an error

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -1,0 +1,14 @@
+# Environment variables for docker-compose command
+
+# Building
+ALPINE_VERSION=latest
+IMAGE_NAME=local/wangxian/alpine-mysql
+
+# Running
+CONTAINER_NAME=mysql
+MYSQL_ROOT_PASSWORD=111111
+MYSQL_USER=tony
+MYSQL_PASSWORD=dpa*12d
+MYSQL_DATABASE=admin
+
+HOST_ADDRESS=3306

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 mysql
+
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,11 @@ MAINTAINER WangXian <xian366@126.com>
 
 WORKDIR /app
 VOLUME /app
-COPY startup.sh /startup.sh
 
 RUN apk add --update mysql mysql-client && rm -f /var/cache/apk/*
+
+# These lines moved to the end allow us to rebuild image quickly after only these files were modified.
+COPY startup.sh /startup.sh
 COPY my.cnf /etc/mysql/my.cnf
 
 EXPOSE 3306

--- a/README.md
+++ b/README.md
@@ -1,15 +1,30 @@
 # alpine-mysql
 a docker image base on alpine with mysql
 
-# build image
+## build image (docker)
 ```
-docker build -t wangxian/alpine-mysql .
-docker run -it --rm -v $(pwd):/app -p 3306:3306 wangxian/alpine-mysql
+docker build -t local/wangxian/alpine-mysql:latest .
+```
+## build image (docker-compose)
+```
+cp .env-dist .env
+nano .env # change environment if you need
+docker-compose build
 ```
 
-# Usage
+## Usage (docker)
 ```
-docker run -it --name mysql -p 3306:3306 -v $(pwd):/app -e MYSQL_DATABASE=admin -e MYSQL_USER=tony -e MYSQL_PASSWORD=dpa\*12d -e MYSQL_ROOT_PASSWORD=111111 wangxian/alpine-mysql
+docker run -it --name mysql -p 3306:3306 -v $(pwd):/app -e MYSQL_DATABASE=admin -e MYSQL_USER=tony -e MYSQL_PASSWORD=dpa\*12d -e MYSQL_ROOT_PASSWORD=111111 local/wangxian/alpine-mysql
 ```
 
-It will create a new db, and set mysql root password(default is 111111)
+## Usage (docker-compose)
+```
+docker-compose up -d
+```
+
+
+It will:
+- set no password for 'root' with localhost connections;
+- set password for 'root' with non-localhost connections (default is '111111');
+- create a new db (default is 'admin');
+- create an user and set his password for non-localhost connections only (defaults are 'tony' and 'dpa*12d').

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '2'
+services:
+
+  mysql:
+    build:
+      dockerfile: Dockerfile
+      context: .
+    image: ${IMAGE_NAME}:${ALPINE_VERSION}
+    container_name: ${CONTAINER_NAME}
+    environment:
+      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
+      - MYSQL_USER=${MYSQL_USER}
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD}
+      - MYSQL_DATABASE=${MYSQL_DATABASE}
+    volumes:
+      - .:/app
+    ports:
+      - "${HOST_ADDRESS}:3306"

--- a/startup.sh
+++ b/startup.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+if [ ! -d "/run/mysqld" ]; then
+  mkdir -p /run/mysqld
+fi
+
 if [ -d /app/mysql ]; then
   echo "[i] MySQL directory already present, skipping creation"
 else
@@ -15,10 +19,6 @@ else
   MYSQL_DATABASE=${MYSQL_DATABASE:-""}
   MYSQL_USER=${MYSQL_USER:-""}
   MYSQL_PASSWORD=${MYSQL_PASSWORD:-""}
-
-  if [ ! -d "/run/mysqld" ]; then
-    mkdir -p /run/mysqld
-  fi
 
   tfile=`mktemp`
   if [ ! -f "$tfile" ]; then


### PR DESCRIPTION
1. Add docker-compose config for easier docker management
2. Fix socket binding error that occurs after server was suddenly halted:
[ERROR] Can't start server : Bind on unix socket: No such file or directory
[ERROR] Do you already have another mysqld server running on socket: /run/mysqld/mysqld.sock ?