### PR TITLE
Added socket path in tmp to prevent socket error on restart

### DIFF
--- a/my.cnf
+++ b/my.cnf
@@ -3,3 +3,4 @@ user = root
 datadir = /app/mysql
 port = 3306
 log-bin = /app/mysql/mysql-bin
+socket = /tmp/mysqld.sock


### PR DESCRIPTION
When mapping a volume to host folder you can't restart the container because of socket error. Moving socket path to tmp solve the issue #4.