### PR TITLE
Fix SQL error in DB init

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -30,7 +30,7 @@ USE mysql;
 FLUSH PRIVILEGES;
 GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' IDENTIFIED BY "$MYSQL_ROOT_PASSWORD" WITH GRANT OPTION;
 GRANT ALL PRIVILEGES ON *.* TO 'root'@'localhost' WITH GRANT OPTION;
-UPDATE user SET password=PASSWORD("") WHERE user='root' AND host='localhost';
+ALTER USER 'root'@'localhost' IDENTIFIED BY '';
 EOF
 
   if [ "$MYSQL_DATABASE" != "" ]; then


### PR DESCRIPTION
**ERROR: 1348  Column 'Password' is not updatable**
I get this error when DB initialisation (first installation). mysql database can't be modified with SQL UPDATE command.